### PR TITLE
Add support for bnb and torch 4-bit optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ To achieve optimal performance, we recommend allocating nodes `vLLM:Actor:Critic
 - Enable the `--colocate_critic_reward`, `--colocate_actor_ref` options to merge nodes.  
 - You should increase the `rollout_micro_batch_size` (and minimize the TP size of vLLM engine) as much as possible. During the training phase, a larger `--micro_train_batch_size` is better and enable `--packing_samples`.
 - When there are enough GPU memory, please disable `--adam_offload` and enable `--overlap_comm`.  Also enable ``--deepcompile`` to speed up the training.
+- Use `--optimizer paged_adamw_8bit` or `--optimizer adamw_torch_4bit` to enable memory efficient optimizers.
 - For vLLM, please use `--vllm_sync_backend nccl`
 - Enable [enable_prefix_caching](https://docs.vllm.ai/en/stable/automatic_prefix_caching/apc.html) in vLLM generation when `n_samples_per_prompts` > 1.
 - For a large base model, if an OOM occurs, do not use any `--colocate_xxxx` options.

--- a/README_ja.md
+++ b/README_ja.md
@@ -441,6 +441,7 @@ python -m openrlhf.cli.lora_combiner \
 - `--colocate_critic_reward`、`--colocate_actor_ref` オプションを有効にしてノードを統合します。
 - `rollout_micro_batch_size` を可能な限り増やし（vLLMエンジンのTPサイズを最小化）、トレーニングフェーズでは `--micro_train_batch_size` を大きくし、`--packing_samples` を有効にしてください。
 - GPUメモリが十分にある場合は、`--adam_offload` を無効にし、`--overlap_comm` を有効にしてください。また、`--deepcompile` を有効にしてトレーニングを高速化してください。
+- メモリ効率の高いオプティマイザを使用するには `--optimizer paged_adamw_8bit` または `--optimizer adamw_torch_4bit` を指定します。
 - vLLMには `--vllm_sync_backend nccl` を使用してください。
 - `n_samples_per_prompts` > 1 の場合は、vLLM生成で [enable_prefix_caching](https://docs.vllm.ai/en/stable/automatic_prefix_caching/apc.html) を有効にしてください。
 - 大規模なベースモデルの場合、OOMが発生した場合は、`--colocate_xxxx` オプションを使用しないでください。

--- a/README_zh.md
+++ b/README_zh.md
@@ -453,6 +453,7 @@ python -m openrlhf.cli.lora_combiner \
 - 启用 `--colocate_critic_reward`、`--colocate_actor_ref` 选项来合并节点。
 - 应该尽可能增加 `rollout_micro_batch_size`（并最小化 vLLM 引擎的 TP 大小）。在训练阶段，较大的 `--micro_train_batch_size` 更好，并启用 `--packing_samples`。
 - 当有足够的 GPU 内存时，请禁用 `--adam_offload` 并启用 `--overlap_comm`。同时启用 `--deepcompile` 来加速训练。
+- 若需使用节省显存的优化器，请设置 `--optimizer paged_adamw_8bit` 或 `--optimizer adamw_torch_4bit`。
 - 对于 vLLM，请使用 `--vllm_sync_backend nccl`
 - 当 `n_samples_per_prompts` > 1 时，在 vLLM 生成中启用 [enable_prefix_caching](https://docs.vllm.ai/en/stable/automatic_prefix_caching/apc.html)。
 - 对于大型基础模型，如果发生 OOM，不要使用任何 `--colocate_xxxx` 选项。

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -199,6 +199,13 @@ if __name__ == "__main__":
     parser.add_argument("--lr_scheduler", type=str, default="cosine_with_min_lr")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
     parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -184,6 +184,13 @@ if __name__ == "__main__":
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
     parser.add_argument("--aux_loss_coef", type=float, default=0, help="MoE balancing loss")

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -173,6 +173,13 @@ if __name__ == "__main__":
     parser.add_argument("--ref_offload", action="store_true", default=False)
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
     parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -274,6 +274,13 @@ if __name__ == "__main__":
     parser.add_argument("--ema_beta", type=float, default=0.992, help="EMA beta coefficient")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--actor_init_on_gpu", action="store_true", default=False)
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -158,6 +158,13 @@ if __name__ == "__main__":
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
     parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -187,6 +187,13 @@ if __name__ == "__main__":
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")
     parser.add_argument("--overlap_comm", action="store_true", default=False)

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -178,6 +178,13 @@ if __name__ == "__main__":
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")
     parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
     parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "paged_adamw_8bit", "adamw_torch_4bit"],
+        help="Optimizer type",
+    )
     parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
     parser.add_argument("--use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
     parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")

--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -13,6 +13,7 @@ def get_train_ds_config(
     use_ds_universal_ckpt=False,
     deepcompile=False,
     tensor_parallel_size=1,
+    allow_untested_optimizer=False,
 ):
     device = "cpu" if offload else "none"
     zero_opt_dict = {
@@ -39,7 +40,7 @@ def get_train_ds_config(
     if stage == 3:
         zero_opt_dict["reduce_scatter"] = True
 
-    return {
+    config = {
         "steps_per_print": 100,
         "zero_optimization": zero_opt_dict,
         "bf16": {
@@ -59,6 +60,9 @@ def get_train_ds_config(
             "autotp_size": tensor_parallel_size,
         },
     }
+    if allow_untested_optimizer and stage >= 2:
+        config["zero_allow_untested_optimizer"] = True
+    return config
 
 
 def get_eval_ds_config(


### PR DESCRIPTION
## Summary
- add `--optimizer` argument to training CLI scripts
- support PagedAdamW8bit and adamw_torch_4bit in DeepspeedStrategy
- allow untested optimizer in deepspeed config when needed
- document optimizer option in README files

## Testing
- `pre-commit run --files README.md README_ja.md README_zh.md openrlhf/cli/train_dpo.py openrlhf/cli/train_kd.py openrlhf/cli/train_kto.py openrlhf/cli/train_ppo_ray.py openrlhf/cli/train_prm.py openrlhf/cli/train_rm.py openrlhf/cli/train_sft.py openrlhf/utils/deepspeed/deepspeed.py openrlhf/utils/deepspeed/deepspeed_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684c661d254c8332bfeba6e52f634c18